### PR TITLE
fixing bib links

### DIFF
--- a/app/sites/documentation-audio.html
+++ b/app/sites/documentation-audio.html
@@ -57,21 +57,19 @@
                         jump to any part within the recording without tedious fast-forwarding and
                         rewinding. </p>
                     <!--l. 143-->
-                    <p> The project &#8220;Freischütz Digital&#8221; offered an interdisciplinary
+                    <p> The project &#x201C;Freisch&#xFC;tz Digital&#x201D; offered an interdisciplinary
                         platform for musicologists and computer scientists to jointly develop and
                         introduce computer-based methods that enhance human involvement with music.
-                        The opera &#8220;Der Freischütz&#8221; by Carl Maria von Weber served as an
+                        The opera &#x201C;Der Freisch&#xFC;tz&#x201D; by Carl Maria von Weber served as an
                         example scenario. This work plays a central role in the Western music
                         literature and is of high relevance for musicological studies. Also, this
                         opera was chosen because of its rich body of available
-                        sources&#8212;including different versions of the musical score, the
+                        sources&#x2014;including different versions of the musical score, the
                         libretto, and audio recordings. One goal of the project was to explore
                         techniques for establishing a virtual archive of relevant digitized objects,
                         including symbolic representations of the autograph score and other musical
-                        sources (encoded in MEI<a href="#fn1" id="ref1"><sup class="textsuperscript"
-                                >1</sup></a>), transcriptions and facsimiles of libretti and other
-                        textual sources (encoded in TEI<a href="#fn2" id="ref2"><sup
-                                class="textsuperscript">2</sup></a>) as well as (multitrack) audio
+                        sources (encoded in MEI<a href="#fn1" id="ref1"><sup class="textsuperscript">1</sup></a>), transcriptions and facsimiles of libretti and other
+                        textual sources (encoded in TEI<a href="#fn2" id="ref2"><sup class="textsuperscript">2</sup></a>) as well as (multitrack) audio
                         recordings of the opera. A more abstract goal within the Computational
                         Humanities was to gain a better understanding of how automated methods may
                         support the work of a musicologist beyond the development of tools for mere
@@ -80,11 +78,7 @@
                     <p> While computer-aided music research relied in earlier times primarily on
                         symbolic representations of the musical score, the focus of recent research
                         efforts has shifted towards the processing and analysis of various types of
-                        music representations including text, audio, and video&#x00A0;<span
-                            class="cite">[<a href="#XLiemMET11_NeedMIR_ACM-MM-MIRUM"
-                                >14</a>,&#x00A0;<a
-                                href="#XMuellerGS12_MultimodalMusicProcessing_DagstuhlFU"
-                            >18</a>]</span>. One particular challenge of the project was to
+                        music representations including text, audio, and video&#xA0;<span class="cite">[<a href="#XLiemMET11_NeedMIR_ACM-MM-MIRUM">14</a>,&#xA0;<a href="#XMuellerGS12_MultimodalMusicProcessing_DagstuhlFU">18</a>]</span>. One particular challenge of the project was to
                         investigate how automated methods and computer-based interfaces may help to
                         coordinate the multiple information sources. While our project partners
                         focused on the encoding and processing of text- and score-based
@@ -94,7 +88,7 @@
                         music recordings. </p>
                     <!--l. 177-->
                     <p> Having a specific focus on the audio domain, we report on our
-                        investigations, results, challenges, and experiences within the Freischütz
+                        investigations, results, challenges, and experiences within the Freisch&#xFC;tz
                         project. Instead of discussing technical details, our goal is to give an
                         intuitive introduction to the various audio processing tasks that have
                         played an important role in the project. Furthermore, we highlight various
@@ -102,77 +96,55 @@
                         real-world scenarios. </p>
                     <!--l. 217-->
                     <p> In the following, we first give an overview of the various types of data
-                        sources that played a role in the Freischütz project, where we have a
-                        particular focus on the audio material (Section&#x00A0;<a href="#x1-20002"
-                            >2<!--tex4ht:ref: sec:data --></a>). Then, we discuss various audio
-                        processing tasks including music segmentation (Section&#x00A0;<a
-                            href="#x1-30003">3<!--tex4ht:ref: sec:seg --></a>), music
-                        synchronization (Section&#x00A0;<a href="#x1-40004"
-                            >4<!--tex4ht:ref: sec:sync --></a>), voice detection (Section&#x00A0;<a
-                            href="#x1-50005">5<!--tex4ht:ref: sec:voice --></a>), and interference
-                        reduction in multitrack recordings (Section&#x00A0;<a href="#x1-60006"
-                            >6<!--tex4ht:ref: sec:multitrack --></a>). For each task, we explain the
-                        relation to the Freischütz project, describe the algorithmic approaches
+                        sources that played a role in the Freisch&#xFC;tz project, where we have a
+                        particular focus on the audio material (Section&#xA0;<a href="#x1-20002">2<!--tex4ht:ref: sec:data --></a>). Then, we discuss various audio
+                        processing tasks including music segmentation (Section&#xA0;<a href="#x1-30003">3<!--tex4ht:ref: sec:seg --></a>), music
+                        synchronization (Section&#xA0;<a href="#x1-40004">4<!--tex4ht:ref: sec:sync --></a>), voice detection (Section&#xA0;<a href="#x1-50005">5<!--tex4ht:ref: sec:voice --></a>), and interference
+                        reduction in multitrack recordings (Section&#xA0;<a href="#x1-60006">6<!--tex4ht:ref: sec:multitrack --></a>). For each task, we explain the
+                        relation to the Freisch&#xFC;tz project, describe the algorithmic approaches
                         applied, discuss their benefits and limitations, and summarize the main
-                        experimental results. Parts of this article are based on the authors&#8217;
-                        publications <span class="cite">[<a
-                                href="#XDittmarLPMW15_SingingVoice_ISMIR">3</a>,&#x00A0;<a
-                                href="#XDittmarPM15_SingingVoice_DAGA">4</a>,&#x00A0;<a
-                                href="#XMuellerPBV13_FreischuetzDigital_WIAMIS">20</a>,&#x00A0;<a
-                                href="#XPraetzlichBLM15_KAMIR_ICASSP">22</a>,&#x00A0;<a
-                                href="#XPraetzlichM13_ReferenceBasedSegmentation_ISMIR"
-                                >23</a>,&#x00A0;<a href="#XPraetzlichM14_AudioTrackSeg_ISMIR"
-                                >24</a>,&#x00A0;<a href="#XRoewenstrunkPBMSV15_WeberOper_DBSK"
-                                >26</a>]</span>, which also contain further details and references
+                        experimental results. Parts of this article are based on the authors&#x2019;
+                        publications <span class="cite">[<a href="#XDittmarLPMW15_SingingVoice_ISMIR">3</a>,&#xA0;<a href="#XDittmarPM15_SingingVoice_DAGA">4</a>,&#xA0;<a href="#XMuellerPBV13_FreischuetzDigital_WIAMIS">20</a>,&#xA0;<a href="#XPraetzlichBLM15_KAMIR_ICASSP">22</a>,&#xA0;<a href="#XPraetzlichM13_ReferenceBasedSegmentation_ISMIR">23</a>,&#xA0;<a href="#XPraetzlichM14_AudioTrackSeg_ISMIR">24</a>,&#xA0;<a href="#XRoewenstrunkPBMSV15_WeberOper_DBSK">26</a>]</span>, which also contain further details and references
                         to related work. </p>
                     <hr/>
                     <h3 id="musicalsources">2. Musical Sources</h3>
                     <!--l. 249-->
                     <p>Music is complex and manifested in many different formats and
-                            modalities&#x00A0;<span class="cite">[<a
-                                href="#XLiemMET11_NeedMIR_ACM-MM-MIRUM">14</a>,&#x00A0;<a
-                                href="#XMuellerGS12_MultimodalMusicProcessing_DagstuhlFU"
-                            >18</a>]</span> (see Figure&#x00A0;<a href="#x1-20021"
-                            >1<!--tex4ht:ref: figure:data --></a>). Taking the opera &#8220;Der
-                        Freischütz&#8221; as an example, we encounter a wide variety of multimedia
+                            modalities&#xA0;<span class="cite">[<a href="#XLiemMET11_NeedMIR_ACM-MM-MIRUM">14</a>,&#xA0;<a href="#XMuellerGS12_MultimodalMusicProcessing_DagstuhlFU">18</a>]</span> (see Figure&#xA0;<a href="#x1-20021">1<!--tex4ht:ref: figure:data --></a>). Taking the opera &#x201C;Der
+                        Freisch&#xFC;tz&#x201D; as an example, we encounter a wide variety of multimedia
                         representations, including <span class="cmti-12">textual
-                        </span>representations in form of the libretto (text of the opera), <span
-                            class="cmti-12">symbolic </span>representations (musical score), <span
-                            class="cmti-12">acoustic </span>representations (audio recordings), and
+                        </span>representations in form of the libretto (text of the opera), <span class="cmti-12">symbolic </span>representations (musical score), <span class="cmti-12">acoustic </span>representations (audio recordings), and
                             <span class="cmti-12">visual </span>representations (video recordings).
-                        In the following, we give some background information on &#8220;Der
-                        Freischütz&#8221; while discussing how different music representations
+                        In the following, we give some background information on &#x201C;Der
+                        Freisch&#xFC;tz&#x201D; while discussing how different music representations
                         naturally appear in various formats and multiple versions in the context of
                         this opera. </p>
                     <!--l. 262-->
-                    <p> Composed by Carl Maria von Weber, &#8220;Der Freischütz&#8221; is a German
+                    <p> Composed by Carl Maria von Weber, &#x201C;Der Freisch&#xFC;tz&#x201D; is a German
                         romantic opera (premiere in 1821), which plays a key role in musicological
                         and historical opera studies. The overture is followed by 16 numbers in the
-                        form of the German &#8220;Singspiel,&#8221; where the music is interspersed
-                        with spoken dialogues&#x00A0;<span class="cite">[<a
-                                href="#XWarrack76_Weber_book">32</a>]</span>. This kind of modular
+                        form of the German &#x201C;Singspiel,&#x201D; where the music is interspersed
+                        with spoken dialogues&#xA0;<span class="cite">[<a href="#XWarrack76_Weber_book">32</a>]</span>. This kind of modular
                         structure allows an opera director for transposing, exchanging, and omitting
                         individual numbers, which has led to many different versions and
                         performances. </p>
                     <!--l. 271-->
                     <p> As for text-based documents, there are detailed accounts on Friedrich
-                        Kind&#8217;s libretto and its underlying plot, which is based on an old
-                        German folk legend (e.g., <span class="cite">[<a
-                                href="#XSchreiter07_FreischuetzLibretto_book">29</a>]</span>). Since
+                        Kind&#x2019;s libretto and its underlying plot, which is based on an old
+                        German folk legend (e.g., <span class="cite">[<a href="#XSchreiter07_FreischuetzLibretto_book">29</a>]</span>). Since
                         its premiere, the libretto has undergone many changes that were introduced
                         by Kind, not to speak of individual changes made by opera directors.
                         Furthermore, there are versions of the opera in other languages such as
                         French, Russian, or Italian being based on translated versions of the
                         libretto. Finally, there exists a rich body of literature on the
-                        opera&#8217;s reception. </p>
+                        opera&#x2019;s reception. </p>
                     <!--l. 280-->
                     <p> On the side of the musical score, there exists a wide range of different
                         sources for the opera. For example, variations have resulted from copying
                         and editing the original autograph score. Changes were not only made by
                         Weber himself, but also by copyists who added further performance
-                        instructions and other details to clarify Weber&#8217;s intention. A
-                        scholarly-critical edition of Weber&#8217;s work<a href="#fn3" id="ref3"
-                                ><sup class="textsuperscript">3</sup></a> keeps track and discusses
+                        instructions and other details to clarify Weber&#x2019;s intention. A
+                        scholarly-critical edition of Weber&#x2019;s work<a href="#fn3" id="ref3"><sup class="textsuperscript">3</sup></a> keeps track and discusses
                         these variations. The recent Music Encoding Initiative (MEI) aims at
                         developing representations and tools to make such enriched score material
                         digitally accessible. Furthermore, there are various derivatives and
@@ -180,16 +152,15 @@
                         composed variants of the originally spoken dialogues (e. g., by Berlioz). </p>
                             <figure>
                                 <img src="pix/figure_data.png" alt="pict"/>
-                        <figcaption>Figure&#x00A0;1: Music-related information in multiple
-                            modalities illustrated by means of the opera &#8220;Der
-                            Freischütz&#8221; by Carl Maria von Weber. </figcaption>
+                        <figcaption>Figure&#xA0;1: Music-related information in multiple
+                            modalities illustrated by means of the opera &#x201C;Der
+                            Freisch&#xFC;tz&#x201D; by Carl Maria von Weber. </figcaption>
                             </figure>
                     <p> As mentioned above, our main focus of this article is the audio domain. Also
-                        for this domain, the opera &#8220;Der Freischütz&#8221; offers a rich body
+                        for this domain, the opera &#x201C;Der Freisch&#xFC;tz&#x201D; offers a rich body
                         of available sources including a large number of recorded performances by
                         various orchestras and soloists. For example, the catalogue of the German
-                        National Library<a href="#fn4" id="ref4"><sup class="textsuperscript"
-                                >4</sup></a> lists 1200 entries for sound carriers containing at
+                        National Library<a href="#fn4" id="ref4"><sup class="textsuperscript">4</sup></a> lists 1200 entries for sound carriers containing at
                         least one musical number of the opera. More than 42 complete recordings have
                         been published and, surely, there still exist many more versions in matters
                         of radio and TV broadcasts. The opera covers a wide range of musical
@@ -215,16 +186,15 @@
                     <hr/>
                     <h3 id="tracksegmentation">3. Track Segmentation</h3>
                     <!--l. 339-->
-                    <p>A first audio processing task that emerged in the Freischütz project concerns
+                    <p>A first audio processing task that emerged in the Freisch&#xFC;tz project concerns
                         the automated segmentation of all available audio recordings of the opera in
-                        a consistent way. As said, the opera &#8220;Der Freischütz&#8221; is a
+                        a consistent way. As said, the opera &#x201C;Der Freisch&#xFC;tz&#x201D; is a
                         number opera starting with an overture followed by 16 numbers, which are
                         interspersed by spoken text (dialogues). When looking at the audio material
                         that originates from CD recordings, the subdivision into CD tracks yields a
                         natural segmentation of the recorded performances. In practice, however, the
                         track segmentations turn out to be rather inconsistent. For example, for 23
-                        different Freischütz recordings, Figure&#x00A0;<a href="#x1-30012"
-                            >2<!--tex4ht:ref: figure:audioSegmentation --></a>a shows the track
+                        different Freisch&#xFC;tz recordings, Figure&#xA0;<a href="#x1-30012">2<!--tex4ht:ref: figure:audioSegmentation --></a>a shows the track
                         segmentations, which vary between 17 and 41 CD tracks per version. In some
                         recordings, each number of the opera was put into a separate CD track,
                         whereas in others the numbers were divided into music and dialogue tracks,
@@ -234,16 +204,16 @@
                         sound carriers (such as shellac, LP, or tape recordings), there may not even
                         exist a meaningful segmentation of the audio material. In order to compare
                         semantically corresponding parts in different versions of the opera, a
-                        consistent segmentation is needed. In the context of the Freischütz project,
+                        consistent segmentation is needed. In the context of the Freisch&#xFC;tz project,
                         such a segmentation was a fundamental requirement for further analysis and
                         processing steps such as the computation of linking structures across
                         different musical sources, including sheet music and audio material (see
-                            Section&#x00A0;<a href="#x1-40004">4<!--tex4ht:ref: sec:sync --></a>). </p>
+                            Section&#xA0;<a href="#x1-40004">4<!--tex4ht:ref: sec:sync --></a>). </p>
                     <div class="graphic">
                         <figure>
                             <img src="pix/figure_audioSegmentation.png" alt="pict"/>
-                            <figcaption>Figure&#x00A0;2: Segmentation of 23 different versions of
-                                &#8220;Der Freischütz&#8221; obtained from commercial CD recordings. (a)
+                            <figcaption>Figure&#xA0;2: Segmentation of 23 different versions of
+                                &#x201C;Der Freisch&#xFC;tz&#x201D; obtained from commercial CD recordings. (a)
                                 Segmentation according to the original CD tracks. (b) Segmentation
                                 according to a reference segmentation specified by a musicologist. The
                                 reference segmentation includes 38 musical sections as well as 16 spoken
@@ -251,9 +221,7 @@
                         </figure>
                     </div>
                     <!--l. 381-->
-                    <p> In&#x00A0;<span class="cite">[<a
-                                href="#XPraetzlichM13_ReferenceBasedSegmentation_ISMIR"
-                            >23</a>]</span>, we presented a reference-based audio segmentation
+                    <p> In&#xA0;<span class="cite">[<a href="#XPraetzlichM13_ReferenceBasedSegmentation_ISMIR">23</a>]</span>, we presented a reference-based audio segmentation
                         approach, which we now describe in more detail. In our scenario, we assumed
                         that a musicologist may be interested in a specific segmentation of the
                         opera. Therefore, as input of our algorithm, the user may specify a
@@ -261,19 +229,16 @@
                         boundaries within a musical score (or another music representation). This
                         annotation is also referred to as <span class="cmti-12">reference
                             segmentation</span>. For example, in our experiments, a musicologist
-                        divided the opera into 38 musical segments and 16 dialogue segments&#8212;a
+                        divided the opera into 38 musical segments and 16 dialogue segments&#x2014;a
                         segmentation that further refines the overture and the 16 numbers of the
                         opera. Our procedure aims at automatically transferring this reference
                         segmentation onto all available recordings of the opera. The desired result
-                        of such a segmentation for 23 Freischütz versions is shown in
-                            Figure&#x00A0;<a href="#x1-30012"
-                            >2<!--tex4ht:ref: figure:audioSegmentation --></a>b. </p>
+                        of such a segmentation for 23 Freisch&#xFC;tz versions is shown in
+                            Figure&#xA0;<a href="#x1-30012">2<!--tex4ht:ref: figure:audioSegmentation --></a>b. </p>
                     <!--l. 395-->
                     <p> As it turned out, the task is more complex as one may think at first glance
                         due to significant acoustic and structural variations across the various
-                        recordings. As our main contributions in&#x00A0;<span class="cite">[<a
-                                href="#XPraetzlichM13_ReferenceBasedSegmentation_ISMIR"
-                            >23</a>]</span>, we applied and adjusted existing synchronization and
+                        recordings. As our main contributions in&#xA0;<span class="cite">[<a href="#XPraetzlichM13_ReferenceBasedSegmentation_ISMIR">23</a>]</span>, we applied and adjusted existing synchronization and
                         matching procedures to realize an automated reference-based segmentation
                         procedure. The second and even more important goal of our investigations was
                         to highlight the benefits and limitations of automated procedures within a
@@ -288,9 +253,9 @@
                     <div class="graphic">
                         <figure>
                             <img src="pix/figure_abridgedVersion.png" alt="pict"/>
-                            <figcaption>Figure&#x00A0;3: (a) Visualization of relative lengths of
+                            <figcaption>Figure&#xA0;3: (a) Visualization of relative lengths of
                                 the segments occuring in abridged versions compared to the reference
-                                version Kle1973. Similar to Figure&#x00A0;2, the gray segments indicate
+                                version Kle1973. Similar to Figure&#xA0;2, the gray segments indicate
                                 dialogues, whereas the colored segments correspond to musical parts.(b)
                                 Illustration of the frame-level segmentation pipeline for abridged
                                 versions.</figcaption>
@@ -301,48 +266,39 @@
                         large-scale musical works may require a huge number of performing musicians.
                         Therefore, such works have often been arranged for smaller ensembles or
                         reduced for piano. Furthermore, performances of operas may have a duration
-                        of up to several hours. Weber&#8217;s opera &#8220;Der Freischütz,&#8221;
+                        of up to several hours. Weber&#x2019;s opera &#x201C;Der Freisch&#xFC;tz,&#x201D;
                         for example, has an average duration of more than two hours. For such
                         large-scale musical works, one often finds abridged versions. These versions
                         usually present the most important material of a musical work in a strongly
                         shortened and structurally modified form. Typically, these structural
                         modifications include omissions of repetitions and other
-                        &#8220;non-essential&#8221; musical passages. Abridged versions were quite
+                        &#x201C;non-essential&#x201D; musical passages. Abridged versions were quite
                         common in the early recording days due to duration constraints of the sound
-                        carriers. For example, the opera &#8220;Der Freischütz&#8221; would have
+                        carriers. For example, the opera &#x201C;Der Freisch&#xFC;tz&#x201D; would have
                         filled 18 shellac discs. More recently, abridged versions or excerpts of a
                         musical work can often be found as bonus tracks on CDs. </p>
                     <!--l. 439-->
-                    <p> In our first approach&#x00A0;<span class="cite">[<a
-                                href="#XPraetzlichM13_ReferenceBasedSegmentation_ISMIR"
-                            >23</a>]</span> as described above, one main assumption was that a given
+                    <p> In our first approach&#xA0;<span class="cite">[<a href="#XPraetzlichM13_ReferenceBasedSegmentation_ISMIR">23</a>]</span> as described above, one main assumption was that a given
                         reference segment either appears more or less in the same form in the
                         unknown version or is omitted completely. In abridged versions of an opera,
                         however, this assumption is often invalid. Such versions strongly deviate
                         from the original by omitting material on different scales, ranging from the
                         omission of several musical measures up to entire parts (see
-                            Figure&#x00A0;<a href="#x1-30023"
-                            >3<!--tex4ht:ref: figure:abridgedVersion --></a>a). For example, given a
+                            Figure&#xA0;<a href="#x1-30023">3<!--tex4ht:ref: figure:abridgedVersion --></a>a). For example, given a
                         segment in a reference version, one may no longer find the start or ending
                         sections of this segment in an unknown version, but only an intermediate
-                        section. In&#x00A0;<span class="cite">[<a
-                                href="#XPraetzlichM14_AudioTrackSeg_ISMIR">24</a>]</span>, we
+                        section. In&#xA0;<span class="cite">[<a href="#XPraetzlichM14_AudioTrackSeg_ISMIR">24</a>]</span>, we
                         addressed the problem of transferring a labeled reference segmentation onto
                         an unknown version in the case of abridged versions. Instead of using a
-                        segment-based procedure as in&#x00A0;<span class="cite">[<a
-                                href="#XPraetzlichM13_ReferenceBasedSegmentation_ISMIR"
-                            >23</a>]</span>, we applied a more flexible frame-level matching
+                        segment-based procedure as in&#xA0;<span class="cite">[<a href="#XPraetzlichM13_ReferenceBasedSegmentation_ISMIR">23</a>]</span>, we applied a more flexible frame-level matching
                         procedure. Here, a frame refers to a short audio excerpt on which a suitable
-                        audio feature is derived. As illustrated by Figure&#x00A0;<a
-                            href="#x1-30023">3<!--tex4ht:ref: figure:abridgedVersion --></a>b, the
+                        audio feature is derived. As illustrated by Figure&#xA0;<a href="#x1-30023">3<!--tex4ht:ref: figure:abridgedVersion --></a>b, the
                         idea is to establish correspondences between frames of a reference version
                         and frames of an unknown version. The labeled segment information of the
                         reference version is then transferred to the unknown version only for frames
                         for which a correspondence has been established. Such a frame-level
                         procedure is more flexible than a segment-level procedure. However, on the
-                        downside, it is less robust. As a main contribution of&#x00A0;<span
-                            class="cite">[<a href="#XPraetzlichM14_AudioTrackSeg_ISMIR"
-                            >24</a>]</span>, we showed how to stabilize the robustness of the
+                        downside, it is less robust. As a main contribution of&#xA0;<span class="cite">[<a href="#XPraetzlichM14_AudioTrackSeg_ISMIR">24</a>]</span>, we showed how to stabilize the robustness of the
                         frame-level matching approach while preserving most of its flexibility. </p>
                     <!--l. 463-->
                     <p> In conclusion, our investigations showed that automated procedures may yield
@@ -355,33 +311,24 @@
                     <hr/>
                     <h3 id="musicsynchronization">4. Music Synchronization</h3>
                     <!--l. 486-->
-                    <p>A central task in the Freischütz project was to link the different
+                    <p>A central task in the Freisch&#xFC;tz project was to link the different
                         information sources such as a given musical score and the many available
                         audio recordings by developing and adapting synchronization techniques.
                         Generally speaking, the goal of music synchronization is to identify and
                         establish links between semantically corresponding events that occur in
-                        different versions and representations <span class="cite">[<a
-                                href="#XDammFTCKM12_DML_IJDL">2</a>,&#x00A0;<a
-                                href="#XEwertMG09_HighResAudioSync_ICASSP">5</a>,&#x00A0;<a
-                                href="#XFujiharaG12_LyricsAudio_DagstuhlFU">6</a>,&#x00A0;<a
-                                href="#XHuDT03_audiomatching_WASPAA">9</a>,&#x00A0;<a
-                                href="#XJoderER11_ConditionalRandomFieldSync_TASLP">10</a>]</span>.
+                        different versions and representations <span class="cite">[<a href="#XDammFTCKM12_DML_IJDL">2</a>,&#xA0;<a href="#XEwertMG09_HighResAudioSync_ICASSP">5</a>,&#xA0;<a href="#XFujiharaG12_LyricsAudio_DagstuhlFU">6</a>,&#xA0;<a href="#XHuDT03_audiomatching_WASPAA">9</a>,&#xA0;<a href="#XJoderER11_ConditionalRandomFieldSync_TASLP">10</a>]</span>.
                         There are many different synchronization scenarios possible depending on the
                         type and nature of the different data sources. For example, in the
-                        Freischütz project, there are different versions of the musical score and
+                        Freisch&#xFC;tz project, there are different versions of the musical score and
                         the libretto (both available as scans and symbolic encodings), as well as a
-                        multitude of audio recordings. In <span class="cmti-12"
-                            >SheetMusic&#8211;Audio synchronization</span>, the task is to link
+                        multitude of audio recordings. In <span class="cmti-12">SheetMusic&#x2013;Audio synchronization</span>, the task is to link
                         regions of a scanned image (given in pixel coordinates) to semantically
                         corresponding time positions within an audio recording (specified on a
-                        physical time axis given in seconds). In <span class="cmti-12"
-                            >SymbolicScore&#8211;Audio</span>
+                        physical time axis given in seconds). In <span class="cmti-12">SymbolicScore&#x2013;Audio</span>
                         <span class="cmti-12">synchronization</span>, the goal is to link time
                         positions in a symbolic score representation (specified on a musical time
                         axis given in measures) with corresponding time positions of an audio
-                        recording (see Figure&#x00A0;<a href="#x1-40014"
-                            >4<!--tex4ht:ref: fig:syncMeasures --></a>). Similarly, in <span
-                            class="cmti-12">Audio&#8211;Audio synchronization</span>, the goal is to
+                        recording (see Figure&#xA0;<a href="#x1-40014">4<!--tex4ht:ref: fig:syncMeasures --></a>). Similarly, in <span class="cmti-12">Audio&#x2013;Audio synchronization</span>, the goal is to
                         time align two different audio recordings of a piece of music. </p>
                     <!--l. 511-->
                     <p> Two versions of the same piece of music can be rather different. For
@@ -392,7 +339,7 @@
                         given versions into suitable mid-level feature representations that
                         facilitate a direct comparison. The symbolic score, for example, is first
                         transformed into a piano-roll like representation only retaining the
-                        notes&#8217; start times, durations, and pitches. Subsequently, all
+                        notes&#x2019; start times, durations, and pitches. Subsequently, all
                         occurring pitches are further reduced to the twelve pitch classes (by
                         ignoring octave information). As a result, one obtains a sequence of
                         so-called <span class="cmti-12">pitch class profiles </span>(often also
@@ -402,13 +349,10 @@
                         audio recording can be transformed into a sequence of chroma features by
                         first transforming it into a time-frequency representation. From this
                         representation, a chroma representation can be derived by grouping
-                        frequencies that belong to the same pitch class, see <span class="cite">[<a
-                                href="#XGomez06_PhD">7</a>,&#x00A0;<a
-                                href="#XMueller07_InformationRetrieval_SPRINGER">17</a>]</span> for
+                        frequencies that belong to the same pitch class, see <span class="cite">[<a href="#XGomez06_PhD">7</a>,&#xA0;<a href="#XMueller07_InformationRetrieval_SPRINGER">17</a>]</span> for
                         details. After transforming both, the score and audio version, into
                         chroma-based representations, the two resulting sequences can be directly
-                        compared using standard alignment techniques&#x00A0;<span class="cite">[<a
-                                href="#XMueller07_InformationRetrieval_SPRINGER">17</a>]</span>. In
+                        compared using standard alignment techniques&#xA0;<span class="cite">[<a href="#XMueller07_InformationRetrieval_SPRINGER">17</a>]</span>. In
                         the same fashion, one may also align two audio recordings of the same piece
                         of music (Audio-Audio synchronization). Note that this is by far not
                         trivial, since different music recordings may vary significantly with regard
@@ -416,27 +360,24 @@
                     <div class="graphic">
                         <figure>
                             <img src="pix/figure_syncMeasure.png" alt="pict"/>
-                            <figcaption>Figure&#x00A0;4: Measure-wise alignment between a sheet
+                            <figcaption>Figure&#xA0;4: Measure-wise alignment between a sheet
                                 music representation and an audio recording. The links are indicated by
                                 the bidirectional red arrows.</figcaption>
                         </figure>
                     </div>
                     <p> Having established linking structures between musical score and available
                         audio versions, one can listen to an audio recording while having the
-                        current position in the musical score highlighted.<a href="#fn5" id="ref5"><sup class="textsuperscript"
-                            >5</sup></a>
+                        current position in the musical score highlighted.<a href="#fn5" id="ref5"><sup class="textsuperscript">5</sup></a>
                         Also, it is possible to use the score as an aid to navigate within an audio
                         version and vice versa. Furthermore, one can use the alignment to seamlessly
                         switch between different recordings, thus making it easier to compare
                         different performances. </p>
                     <!--l. 568-->
-                    <p> One particular challenge in the Freischütz project are structural variations
-                        as discussed in Section&#x00A0;<a href="#x1-30003"
-                            >3<!--tex4ht:ref: sec:seg --></a>. In the presence of such variations,
+                    <p> One particular challenge in the Freisch&#xFC;tz project are structural variations
+                        as discussed in Section&#xA0;<a href="#x1-30003">3<!--tex4ht:ref: sec:seg --></a>. In the presence of such variations,
                         the synchronization task may not even be well-defined. Our idea for
-                        synchronizing the different versions of &#8220;Der Freischütz&#8221; was to
-                        first use the segmentation techniques from Section&#x00A0;<a
-                            href="#x1-30003">3<!--tex4ht:ref: sec:seg --></a> in order to identify
+                        synchronizing the different versions of &#x201C;Der Freisch&#xFC;tz&#x201D; was to
+                        first use the segmentation techniques from Section&#xA0;<a href="#x1-30003">3<!--tex4ht:ref: sec:seg --></a> in order to identify
                         semantically corresponding parts between the versions to be aligned. This
                         reduces the synchronization problem into smaller subproblems, as only the
                         semantically corresponding parts are synchronized in the subsequent step
@@ -447,15 +388,13 @@
                     <!--l. 585-->
                     <p> In the case that a reliable prior segmentation is not available, one has to
                         find strategies to compute the alignment even for entire recordings. For
-                        example, to synchronize two complete Freischütz recordings, one has to deal
+                        example, to synchronize two complete Freisch&#xFC;tz recordings, one has to deal
                         with roughly five hours of audio material, leading to computational
                         challenges with regard to memory requirements and running time. As one
-                        technical contribution within the Freischütz project, we extended an
+                        technical contribution within the Freisch&#xFC;tz project, we extended an
                         existing multiscale alignment technique that uses an alignment on a coarse
                         resolution to constrain an alignment on a finer grained
-                            resolution&#x00A0;<span class="cite">[<a
-                                href="#XMuellerMK06_MsDTW_ISMIR">19</a>,&#x00A0;<a
-                                href="#XSalvadorC04_fastDTW">27</a>]</span>. In our modified
+                            resolution&#xA0;<span class="cite">[<a href="#XMuellerMK06_MsDTW_ISMIR">19</a>,&#xA0;<a href="#XSalvadorC04_fastDTW">27</a>]</span>. In our modified
                         approach, we proceed in a block-by-block fashion, where an additional block
                         size parameter is introduced to explicitly control the memory requirements.
                         In our experiments, we found that a maximum block size of about eight
@@ -463,19 +402,18 @@
                         synchronization algorithm without these restrictions. Similar to previously
                         introduced multiscale alignment strategies, our novel procedure drastically
                         reduces the memory requirements and runtimes. In contrast to the previous
-                            approach&#x00A0;<span class="cite">[<a href="#XMuellerMK06_MsDTW_ISMIR"
-                                >19</a>]</span>, our block-by-block processing strategy allows for
+                            approach&#xA0;<span class="cite">[<a href="#XMuellerMK06_MsDTW_ISMIR">19</a>]</span>, our block-by-block processing strategy allows for
                         an explicit control over the required memory while being easy to implement.
                         Furthermore, the block-by-block processing allows for a parallel
                         implementation of the procedure. </p>
                     <!--l. 620-->
-                    <p> From a practical perspective, one challenge in the Freischütz project was
+                    <p> From a practical perspective, one challenge in the Freisch&#xFC;tz project was
                         the handling of the many different formats used to encode symbolic music
                         representations. In view of the alignment task, as mentioned above, we
                         needed to convert the score representation into a piano-roll like
                         representation which can easily be derived from a MIDI file. In the project,
                         the encoding of the score representations started with the creation of
-                        scores in the commercial music notation software &#8220;Finale.&#8221; The
+                        scores in the commercial music notation software &#x201C;Finale.&#x201D; The
                         proprietary file format was then exported into MusicXML, which is a more
                         universal format for storing music files and sharing them between different
                         music notation applications. To account for the needs of critical music
@@ -487,7 +425,7 @@
                         which could then be converted into a MIDI representation. Only at the end of
                         the project, we realized that the MIDI export could have been directly
                         obtained by conversion from the original Finale files. From this
-                        &#8220;detour&#8221; we have learned the lesson that there is no format that
+                        &#x201C;detour&#x201D; we have learned the lesson that there is no format that
                         serves equally well for all purposes. Moreover, the decision for a common
                         file format should be made under careful consideration of the availability
                         and maturity of editing and processing tools. </p>
@@ -495,80 +433,68 @@
                     <p> Even though such experiences are sometimes frustrating, we are convinced
                         that the exploration of novel formats as well as the adaption and
                         development of suitable tools has been one major scientific contribution of
-                        the Freischütz project. </p>
+                        the Freisch&#xFC;tz project. </p>
                     <hr/>
                     <h3 id="dialogue">5. Dialogue and Singing Voice Detection</h3>
                     <div class="graphic">
                         <figure>
                             <img src="pix/figure_voiceStructure.png" alt="pict"/>
-                            <figcaption>Figure&#x00A0;5: Different representations of the song
-                                &#8220;Hier im ird&#8217;schen Jammerthal&#8221; (No.&#x00A0;4) of
-                                &#8220;Der Freischütz.&#8221; (a)&#x00A0;Score representation. In this
+                            <figcaption>Figure&#xA0;5: Different representations of the song
+                                &#x201C;Hier im ird&#x2019;schen Jammerthal&#x201D; (No.&#xA0;4) of
+                                &#x201C;Der Freisch&#xFC;tz.&#x201D; (a)&#xA0;Score representation. In this
                                 song, after an intro (red), the repeated verses (yellow) are interleaved
                                 with spoken dialogues (blue). According to the score, there are three
-                                verses. (b)&#x00A0;Waveform of a recorded performance conducted by
+                                verses. (b)&#xA0;Waveform of a recorded performance conducted by
                                 Carlos Kleiber. The performance follows the structure specified by the
-                                above score. (c)&#x00A0;Waveform of a recorded performance conducted by
+                                above score. (c)&#xA0;Waveform of a recorded performance conducted by
                                 Otto Ackermann. In this performance, the structure deviates from the
                                 score by omitting the second dialogue and the third verse as well as by
                                 drastically shortening the final dialogue.</figcaption>
                         </figure>
                     </div>
-                    <p> As explained in Section&#x00A0;<a href="#x1-20002"
-                            >2<!--tex4ht:ref: sec:data --></a>, the opera &#8220;Der
-                        Freischütz&#8221; consists of musical numbers that are interspersed with
+                    <p> As explained in Section&#xA0;<a href="#x1-20002">2<!--tex4ht:ref: sec:data --></a>, the opera &#x201C;Der
+                        Freisch&#xFC;tz&#x201D; consists of musical numbers that are interspersed with
                         dialogues. These spoken dialogues constitute an important part of the opera
                         as they convey the story line. In view of the segmentation and
-                        synchronization tasks, knowing the dialogue sections of an opera&#8217;s
-                        recording are important cues. This is illustrated by Figure&#x00A0;<a
-                            href="#x1-50015">5<!--tex4ht:ref: figure:voiceStructure --></a>, which
-                        shows various representations of the song &#8220;Hier im ird&#8217;schen
-                        Jammerthal&#8221; (No.&#x00A0;4). This song consists of an intro (only
+                        synchronization tasks, knowing the dialogue sections of an opera&#x2019;s
+                        recording are important cues. This is illustrated by Figure&#xA0;<a href="#x1-50015">5<!--tex4ht:ref: figure:voiceStructure --></a>, which
+                        shows various representations of the song &#x201C;Hier im ird&#x2019;schen
+                        Jammerthal&#x201D; (No.&#xA0;4). This song consists of an intro (only
                         orchestra) and three verses with different lyrics, but with the same
                         underlying music (notated as repetitions). After each verse, there is a
                         dialogue section. While it is trivial to identify the dialogue sections and
                         the musical structure in a sheet music representation of the song
-                            (Figure&#x00A0;<a href="#x1-50015"
-                            >5<!--tex4ht:ref: figure:voiceStructure --></a>a), this becomes a much
+                            (Figure&#xA0;<a href="#x1-50015">5<!--tex4ht:ref: figure:voiceStructure --></a>a), this becomes a much
                         harder problem when considering audio recordings of a performance. While the
-                        Kleiber recording (Figure&#x00A0;<a href="#x1-50015"
-                            >5<!--tex4ht:ref: figure:voiceStructure --></a>b) follows the structure
+                        Kleiber recording (Figure&#xA0;<a href="#x1-50015">5<!--tex4ht:ref: figure:voiceStructure --></a>b) follows the structure
                         as specified in the score, there are omissions in the Ackermann recording
-                            (Figure&#x00A0;<a href="#x1-50015"
-                            >5<!--tex4ht:ref: figure:voiceStructure --></a>c). Knowing the dialogue
+                            (Figure&#xA0;<a href="#x1-50015">5<!--tex4ht:ref: figure:voiceStructure --></a>c). Knowing the dialogue
                         sections, these structural differences between the two recordings can be
                         understood immediately. </p>
                     <!--l. 761-->
                     <p> In audio signal processing, the task of discriminating between speech and
-                        music signals is a well-studied problem&#x00A0;<span class="cite">[<a
-                                href="#XSaunders96_SpeechMusicDiscrimination_ICASSP"
-                                >28</a>,&#x00A0;<a href="#XSonnleitnerNW12_SpeechDetection_DAFX"
-                                >30</a>]</span>. Most procedures for speech/music discrimination use
+                        music signals is a well-studied problem&#xA0;<span class="cite">[<a href="#XSaunders96_SpeechMusicDiscrimination_ICASSP">28</a>,&#xA0;<a href="#XSonnleitnerNW12_SpeechDetection_DAFX">30</a>]</span>. Most procedures for speech/music discrimination use
                         machine learning techniques that automatically learn a model from example
                         inputs (i.e., audio material labeled as speech and audio material labeled as
                         music) in order to make data-driven predictions or decisions for unknown
-                        audio material&#x00A0;<span class="cite">[<a
-                                href="#XBishop06_PatternRecognition_Book">1</a>]</span>. The task of
+                        audio material&#xA0;<span class="cite">[<a href="#XBishop06_PatternRecognition_Book">1</a>]</span>. The task of
                         speech/music discrimination is an important step for automated speech
-                        recognition and general multimedia applications. Within the Freischütz
+                        recognition and general multimedia applications. Within the Freisch&#xFC;tz
                         project, we have applied and adapted existing speech/music classification
-                        approaches to support our segmentation (Section&#x00A0;<a href="#x1-30003"
-                            >3<!--tex4ht:ref: sec:seg --></a>) and synchronization approaches
-                            (Section&#x00A0;<a href="#x1-40004">4<!--tex4ht:ref: sec:sync --></a>).
+                        approaches to support our segmentation (Section&#xA0;<a href="#x1-30003">3<!--tex4ht:ref: sec:seg --></a>) and synchronization approaches
+                            (Section&#xA0;<a href="#x1-40004">4<!--tex4ht:ref: sec:sync --></a>).
                         Within our opera scenario, it is beneficial to also consider additional
                         classes that correspond to applause and passages of silence. Such extensions
-                        have also been discussed extensively in the literature&#x00A0;<span
-                            class="cite">[<a href="#XPatsisV08_SpeechMusicGarbage_DEXA"
-                            >21</a>]</span>. </p>
+                        have also been discussed extensively in the literature&#xA0;<span class="cite">[<a href="#XPatsisV08_SpeechMusicGarbage_DEXA">21</a>]</span>. </p>
                     <div class="graphic">
                         <figure>
                             <img src="pix/figure_singDetection.png" alt="pict"/>
-                            <figcaption>Figure&#x00A0;6: Illustration of the singing voice
-                                detection task. (a)&#x00A0; Score representations of measures 7 to 12 of
-                                the song &#8220;Wie nahte mir der Schlummer&#8221; (No.&#x00A0;8) of
-                                &#8220;Der Freischütz.&#8221; The singing voice sections are highlighted
-                                in light red. (b)&#x00A0;Waveform of a recorded performance.
-                                (c)&#x00A0;Decision function (black curve) of an automated classifier.
+                            <figcaption>Figure&#xA0;6: Illustration of the singing voice
+                                detection task. (a)&#xA0; Score representations of measures 7 to 12 of
+                                the song &#x201C;Wie nahte mir der Schlummer&#x201D; (No.&#xA0;8) of
+                                &#x201C;Der Freisch&#xFC;tz.&#x201D; The singing voice sections are highlighted
+                                in light red. (b)&#xA0;Waveform of a recorded performance.
+                                (c)&#xA0;Decision function (black curve) of an automated classifier.
                                 The function should assume large values (close to one) for time points
                                 with singing voice and small values (close to zero) otherwise. The final
                                 decision is derived from the curve by using a suitable threshold (dashed
@@ -581,10 +507,7 @@
                             <span class="cmti-12">singing voice detection</span>, where the
                         objective is to automatically segment a given music recording into vocal
                         (where one or more singers are active) and non-vocal (only accompaniment or
-                        silence) sections&#x00A0;<span class="cite">[<a
-                                href="#XLehnerWS14_SingingVoice_ICASSP">13</a>,&#x00A0;<a
-                                href="#XMauchFYG11_VocalDetect_ISMIR">16</a>,&#x00A0;<a
-                                href="#XRamonaRD08_VocalDetect_ICASSP">25</a>]</span>. Due to the
+                        silence) sections&#xA0;<span class="cite">[<a href="#XLehnerWS14_SingingVoice_ICASSP">13</a>,&#xA0;<a href="#XMauchFYG11_VocalDetect_ISMIR">16</a>,&#xA0;<a href="#XRamonaRD08_VocalDetect_ICASSP">25</a>]</span>. Due to the
                         huge variety of singing voice characteristics as well as the simultaneous
                         presence of other pitched musical instruments in the accompaniment, singing
                         voice detection is generally considered a much harder problem than
@@ -600,18 +523,13 @@
                     <p> Technically similar to speech/music discrimination, most approaches for
                         singing voice detection build upon extracting a set of suitable audio
                         features and subsequently applying machine learning in the classification
-                        stage, see&#x00A0;<span class="cite">[<a
-                                href="#XLehnerWS14_SingingVoice_ICASSP">13</a>,&#x00A0;<a
-                                href="#XMauchFYG11_VocalDetect_ISMIR">16</a>,&#x00A0;<a
-                                href="#XRamonaRD08_VocalDetect_ICASSP">25</a>]</span>. These
+                        stage, see&#xA0;<span class="cite">[<a href="#XLehnerWS14_SingingVoice_ICASSP">13</a>,&#xA0;<a href="#XMauchFYG11_VocalDetect_ISMIR">16</a>,&#xA0;<a href="#XRamonaRD08_VocalDetect_ICASSP">25</a>]</span>. These
                         approaches need extensive training material that reflects the acoustic
                         variance of the classes to be learned. In particular, we used a
                         state-of-the-art singing voice detection system that was originally
-                        introduced in&#x00A0;<span class="cite">[<a
-                                href="#XLehnerWS14_SingingVoice_ICASSP">13</a>]</span>. This
+                        introduced in&#xA0;<span class="cite">[<a href="#XLehnerWS14_SingingVoice_ICASSP">13</a>]</span>. This
                         approach employs a classification scheme known as random forests to derive a
-                        time-dependent decision function (see Figure&#x00A0;<a href="#x1-50026"
-                            >6<!--tex4ht:ref: figure:singDetection --></a>c). The idea is that the
+                        time-dependent decision function (see Figure&#xA0;<a href="#x1-50026">6<!--tex4ht:ref: figure:singDetection --></a>c). The idea is that the
                         decision function should assume large values close to one for time points
                         with singing voice (vocal class) and small values close to zero otherwise
                         (non-vocal class). In order to binarize the decision function, it is
@@ -620,17 +538,13 @@
                     <!--l. 843-->
                     <p> In particular for popular music, annotated datasets for training and
                         evaluation of singing voice detection algorithms are publicly
-                            available&#x00A0;<span class="cite">[<a
-                                href="#XRamonaRD08_VocalDetect_ICASSP">25</a>]</span>. In the
-                        context of the Freischütz project, we looked at the singing voice detection
+                            available&#xA0;<span class="cite">[<a href="#XRamonaRD08_VocalDetect_ICASSP">25</a>]</span>. In the
+                        context of the Freisch&#xFC;tz project, we looked at the singing voice detection
                         problem for the case of classical opera recordings. Not surprising, first
                         experiments showed that a straightforward application of previous approaches
                         (trained on popular music) typically lead to poor classification results
-                        when directly applied to classical music. In&#x00A0;<span class="cite">[<a
-                                href="#XDittmarLPMW15_SingingVoice_ISMIR">3</a>,&#x00A0;<a
-                                href="#XDittmarPM15_SingingVoice_DAGA">4</a>]</span>, we proposed
-                        various modifications of the system described in&#x00A0;<span class="cite"
-                                >[<a href="#XLehnerWS14_SingingVoice_ICASSP">13</a>]</span>. As one
+                        when directly applied to classical music. In&#xA0;<span class="cite">[<a href="#XDittmarLPMW15_SingingVoice_ISMIR">3</a>,&#xA0;<a href="#XDittmarPM15_SingingVoice_DAGA">4</a>]</span>, we proposed
+                        various modifications of the system described in&#xA0;<span class="cite">[<a href="#XLehnerWS14_SingingVoice_ICASSP">13</a>]</span>. As one
                         contribution, we proposed novel audio features that extend a feature set
                         previously used for popular music recordings. Then, we described a
                         bootstrapping procedure that helps to improve the results in the case that
@@ -646,8 +560,8 @@
                     <hr/>
                     <h3 id="processing">6. Processing of Multitrack Recordings</h3>
                     <!--l. 878-->
-                    <p>In the Freischütz project, a professional recording of No.&#x00A0;6 (duet),
-                        No.&#x00A0;8 (aria), No.&#x00A0;9 (trio) of &#8220;Der Freischütz&#8221; was
+                    <p>In the Freisch&#xFC;tz project, a professional recording of No.&#xA0;6 (duet),
+                        No.&#xA0;8 (aria), No.&#xA0;9 (trio) of &#x201C;Der Freisch&#xFC;tz&#x201D; was
                         produced in cooperation with Tonmeister students from the
                         Erich-Thienhaus-Institute (ETI) in Detmold. The main purpose for the
                         recording sessions was to produce royalty free audio material that can be
@@ -658,16 +572,13 @@
                         stereo mixes of specific instrument sections and a professionally produced
                         stereo mix of the whole orchestra. Additionally, several variants of the
                         musical score that are relevant for the scholarly edition were recorded to
-                        illustrate how these variants sound in an actual performance&#x00A0;<span
-                            class="cite">[<a href="#XKepperSV14_Freischuetz_EDITIO"
-                                >11</a>]</span>.<a href="#fn6" id="ref6"><sup class="textsuperscript"
-                                    >6</sup></a>
+                        illustrate how these variants sound in an actual performance&#xA0;<span class="cite">[<a href="#XKepperSV14_Freischuetz_EDITIO">11</a>]</span>.<a href="#fn6" id="ref6"><sup class="textsuperscript">6</sup></a>
                     </p>
                     <div class="graphic">
                         <figure>
                             <img src="pix/figure_orchestra.png" alt="pict"/>
                             <img src="pix/figure_ochestraMics.png" alt="pict"/>
-                            <figcaption>Figure&#x00A0;7: Recording setup used in the Freischütz
+                            <figcaption>Figure&#xA0;7: Recording setup used in the Freisch&#xFC;tz
                                 project. (a) Seating plan (German/European style). (b) Setup of the 25
                                 microphones used in the recordings, involving two main microphones for
                                 recording a stereo image and at least one spot microphone for each
@@ -678,8 +589,7 @@
                         </figure>
                     </div>
                     <p> Orchestra recordings typically involve a huge number of musicians and
-                        different instruments. Figure&#x00A0;<a href="#x1-60027"
-                            >7<!--tex4ht:ref: figure:orchestra --></a>a shows the orchestra&#8217;s
+                        different instruments. Figure&#xA0;<a href="#x1-60027">7<!--tex4ht:ref: figure:orchestra --></a>a shows the orchestra&#x2019;s
                         seating plan, which indicates where each voice (instrument section or
                         singer) was positioned in the room. The seating plan also reflects the
                         number of musicians that were playing in each instrument section. Overall,
@@ -688,19 +598,16 @@
                         important. For example, each instrument section has a principal musician who
                         leads the other musicians of the section. To make this interaction possible,
                         the different voices are usually recorded in the same room simultaneously.
-                            Figure&#x00A0;<a href="#x1-60027"
-                            >7<!--tex4ht:ref: figure:orchestra --></a>b shows the microphones used
-                        for the different voices and their relative position in the room.<a href="#fn7" id="ref7"><sup class="textsuperscript"
-                            >7</sup></a>
+                            Figure&#xA0;<a href="#x1-60027">7<!--tex4ht:ref: figure:orchestra --></a>b shows the microphones used
+                        for the different voices and their relative position in the room.<a href="#fn7" id="ref7"><sup class="textsuperscript">7</sup></a>
                         Two main microphones were used for recording a stereo image of the sound in
                         the room. For capturing the sound of individual voices, at least one
                         additional spot microphone was positioned close to each voice. For some of
                         the instrument sections, additional spot microphones were used, see
-                            Figure&#x00A0;<a href="#x1-60027"
-                            >7<!--tex4ht:ref: figure:orchestra --></a>b. The first violin section,
+                            Figure&#xA0;<a href="#x1-60027">7<!--tex4ht:ref: figure:orchestra --></a>b. The first violin section,
                         for example, was recorded with three microphones: one at the front position,
                         one at the rear position, and a clip microphone attached to the principal
-                        musician&#8217;s instrument. The audio tracks recorded by the spot
+                        musician&#x2019;s instrument. The audio tracks recorded by the spot
                         microphones allow a sound engineer to balance out the volume of the
                         different voices in the mixing process. Usually, a voice is captured by its
                         spot microphones before it arrives at the main microphones which are
@@ -717,50 +624,41 @@
                         covers a few musical measures up to the whole piece. An audio engineer then
                         merges the best combination of takes for the final production. This is done
                         by fading from one take into another at suitable positions in the audio
-                        tracks. The merged takes are then used to produce a stereo mixture.<a href="#fn8" id="ref8"><sup class="textsuperscript"
-                            >8</sup></a> In
+                        tracks. The merged takes are then used to produce a stereo mixture.<a href="#fn8" id="ref8"><sup class="textsuperscript">8</sup></a> In
                         our case, additional stereo mixes that emphasize different aspects of the
                         piece of music were produced. First, a stereo mixture including all voices
                         and microphones was produced. This is the kind of mixture one usually finds
                         in professionally produced CD recordings. For demonstration purposes,
                         additional stereo mixtures were produced for each individual voice (see
-                            Figure&#x00A0;<a href="#x1-60027"
-                            >7<!--tex4ht:ref: figure:orchestra --></a>a), as well as for instrument
+                            Figure&#xA0;<a href="#x1-60027">7<!--tex4ht:ref: figure:orchestra --></a>a), as well as for instrument
                         groups including the woodwinds (bassoon, flute, clarinet, oboe), the strings
                         (violin 1, violin 2, viola, cello, double bass), and the singers. </p>
                     <!--l. 987-->
                     <p> In a typical professional setup, the recording room is equipped with sound
                         absorbing materials and acoustic shields to isolate all the voices as much
                         as possible. However, complete acoustic isolation between the voices is
-                        often not possible. In practice and as depicted in Figure&#x00A0;<a
-                            href="#x1-60058">8<!--tex4ht:ref: figure:bleedingReduction --></a>a,
+                        often not possible. In practice and as depicted in Figure&#xA0;<a href="#x1-60058">8<!--tex4ht:ref: figure:bleedingReduction --></a>a,
                         each microphone not only records sound from its dedicated voice, but also
                         from all others in the room. This results in recordings that do not feature
                         isolated signals, but rather mixtures of a predominant voice with all others
-                        being audible through what is referred to as <span class="cmti-12"
-                            >interference</span>, <span class="cmti-12">bleeding</span>, <span
-                            class="cmti-12">crosstalk</span>, or <span class="cmti-12"
-                            >leakage</span>. Such interferences are annoying in practice for several
+                        being audible through what is referred to as <span class="cmti-12">interference</span>, <span class="cmti-12">bleeding</span>, <span class="cmti-12">crosstalk</span>, or <span class="cmti-12">leakage</span>. Such interferences are annoying in practice for several
                         reasons. First, interferences greatly reduce the mixing possibilities for a
                         sound engineer, and second, they prevent the removal or isolation of a voice
-                        from the recording, which may be desirable, e.g.&#x00A0;for pedagogical
-                        reasons or &#8220;music minus one&#8221; applications (mixtures where a
+                        from the recording, which may be desirable, e.g.&#xA0;for pedagogical
+                        reasons or &#x201C;music minus one&#x201D; applications (mixtures where a
                         particular voice has been removed). An important question thus arises: is it
                         possible to reduce or remove these interferences to get clean, isolated
                         voice signals? Interference Reduction is closely related to the problem of
                         audio source separation, in which the objective is to separate a sound
-                        mixture into its constituent components&#x00A0;<span class="cite">[<a
-                                href="#XVincentBGB14_SourceSep_IEEE-SPM">31</a>]</span>. Audio
+                        mixture into its constituent components&#xA0;<span class="cite">[<a href="#XVincentBGB14_SourceSep_IEEE-SPM">31</a>]</span>. Audio
                         source separation in general is a very difficult problem where performance
                         is highly dependent on the signals considered. However, recent studies
                         demonstrate that separation methods can be very effective if prior
-                        information about the signals is available (see e.g.&#x00A0;<span
-                            class="cite">[<a href="#XLiutkusDDR13_InformedSourceSep_WIAMIS"
-                            >15</a>]</span> and references therein). </p>
+                        information about the signals is available (see e.g.&#xA0;<span class="cite">[<a href="#XLiutkusDDR13_InformedSourceSep_WIAMIS">15</a>]</span> and references therein). </p>
                     <div class="graphic">
                         <figure>
                             <img src="pix/figure_bleedingReduction.png" alt="pict"/>
-                            <figcaption>Figure&#x00A0;8: (a) Illustration of interference problem
+                            <figcaption>Figure&#xA0;8: (a) Illustration of interference problem
                                 in a recording with three voices (violin section, bass, singing voice).
                                 A solid line (red) indicates that a voice is associated to a microphone,
                                 a dashed line (gray) indicates interference from another voice into a
@@ -770,28 +668,22 @@
                         <!--tex4ht:label?: x1-60058 -->
                     </div>
                     <!--l. 1015-->
-                    <p> In&#x00A0;<span class="cite">[<a href="#XPraetzlichBLM15_KAMIR_ICASSP"
-                                >22</a>]</span>, we presented a method that aims to reduce
+                    <p> In&#xA0;<span class="cite">[<a href="#XPraetzlichBLM15_KAMIR_ICASSP">22</a>]</span>, we presented a method that aims to reduce
                         inferences in multitrack recordings to recover only the isolated voices. In
-                        our approach, similar to <span class="cite">[<a
-                                href="#XKokkinisRM12_MultiChannelLeakageSuppression_IEEE-TASLP"
-                                >12</a>]</span>, we exploit the fact that each voice can be assumed
+                        our approach, similar to <span class="cite">[<a href="#XKokkinisRM12_MultiChannelLeakageSuppression_IEEE-TASLP">12</a>]</span>, we exploit the fact that each voice can be assumed
                         to be predominant in its dedicated microphones. Our method iteratively
                         estimates both the time-frequency content of each voice and the
                         corresponding strength in each microphone signal. With this information, we
-                        build a filter that strongly reduces the interferences. Figure&#x00A0;<a
-                            href="#x1-60058">8<!--tex4ht:ref: figure:bleedingReduction --></a>b
+                        build a filter that strongly reduces the interferences. Figure&#xA0;<a href="#x1-60058">8<!--tex4ht:ref: figure:bleedingReduction --></a>b
                         shows an example of an interference reduced version of the singing voice
-                        signal from Figure&#x00A0;<a href="#x1-60058"
-                            >8<!--tex4ht:ref: figure:bleedingReduction --></a>a. Especially in the
+                        signal from Figure&#xA0;<a href="#x1-60058">8<!--tex4ht:ref: figure:bleedingReduction --></a>a. Especially in the
                         middle of the corresponding waveforms, it is easy to spot differences. In
                         this region, there was no singing voice in the recording. Hence, the
                         recorded signal in this region originated entirely from interference of
                         other instrumental voices. </p>
                     <!--l. 1031-->
-                    <p> In the Freischütz project, we processed the multitrack recordings of the
-                        opera to reduce the interferences in the spot microphones.<a href="#fn9" id="ref9"><sup class="textsuperscript"
-                            >9</sup></a>
+                    <p> In the Freisch&#xFC;tz project, we processed the multitrack recordings of the
+                        opera to reduce the interferences in the spot microphones.<a href="#fn9" id="ref9"><sup class="textsuperscript">9</sup></a>
                         Although the effectiveness of our method has been shown in listening tests,
                         such processings still go along with artifacts that are audible when
                         listening to each interference reduced microphone signal separately.
@@ -836,186 +728,326 @@
                     <p id="fn7">7. For No.&#x00A0;6 and No.&#x00A0;8, 23 microphones were used to
                         record 11 voices. For No.&#x00A0;9, 24 microphones were used to record 12
                         voices. 
-                        <a href="#ref7" title="Jump back to footnote 7 in the text."
-                        >↩</a></p>
+                        <a href="#ref7" title="Jump back to footnote 7 in the text.">&#x21A9;</a></p>
                     <p id="fn8">8. After merging the different takes, the resulting raw audio
                         material as well as the versions with delay compensation and equalizers were
                         exported for each microphone. In the remaining mixing process, only the
-                        versions with delay compensation and equalizers were used. <a href="#ref8"
-                            title="Jump back to footnote 8 in the text.">↩</a></p>
+                        versions with delay compensation and equalizers were used. <a href="#ref8" title="Jump back to footnote 8 in the text.">&#x21A9;</a></p>
                     <p id="fn9">9. Sound examples can be found at 
                         <a href="http://www.audiolabs-erlangen.de/resources/MIR/2015-ICASSP-KAMIR/" class="url">http://www.audiolabs-erlangen.de/resources/MIR/2015-ICASSP-KAMIR/</a>
-                        <a href="#ref9" title="Jump back to footnote 9 in the text."
-                            >↩</a></p>
+                        <a href="#ref9" title="Jump back to footnote 9 in the text.">&#x21A9;</a></p>
 
                     <hr/>
                     <h3 id="references">References</h3>
                     <!--l. 1-->
                     <div class="thebibliography">
-                        <p>[1]&#x00A0;&#x00A0;&#x00A0;Christopher&#x00A0;M.
-                            Bishop. Pattern recognition and machine
-                                learning. Springer, New York, 2006. </p>
-                        <p>[2]&#x00A0;&#x00A0;&#x00A0;David Damm, Christian Fremerey, Verena
-                            Thomas, Michael Clausen, Frank Kurth, and Meinard Müller. A digital
-                            library framework for heterogeneous music collections: from document
-                            acquisition to cross-modal interaction. International Journal on Digital Libraries:
-                            Special Issue on Music Digital Libraries,
-                            12(2-3):53&#8211;71, 2012. </p>
-                        <p>[3]&#x00A0;&#x00A0;&#x00A0;Christian Dittmar, Bernhard
-                            Lehner, Thomas Prätzlich, Meinard Müller, and Gerhard Widmer.
-                            Cross-version singing voice detection in classical opera recordings. In
-                              Proceedings of the International Society
-                            for Music Information Retrieval Conference
-                                (ISMIR), Malaga, Spain, October 2015. </p>
-                        <p>[4]&#x00A0;&#x00A0;&#x00A0;Christian Dittmar, Thomas
-                            Prätzlich, and Meinard Müller. Towards cross-version singing voice
-                            detection. In Proceedings of the
-                                Jahrestagung für Akustik
-                                (DAGA), Nuremberg, Germany, March 2015. </p>
-                        <p>[5]&#x00A0;&#x00A0;&#x00A0;Sebastian Ewert, Meinard
-                            Müller, and Peter Grosche. High resolution audio synchronization using
-                            chroma onset features. In Proceedings of the IEEE
-                                International Conference on Acoustics, Speech,
-                            and Signal Processing (ICASSP), pages
-                            1869&#8211;1872, Taipei, Taiwan, 2009. </p>
-                        <p>[6]&#x00A0;&#x00A0;&#x00A0;Hiromasa Fujihara and
-                            Masataka Goto. Lyrics-to-audio alignment and its application. In Meinard
-                            Müller, Masataka Goto, and Markus Schedl, editors, Multimodal Music Processing, volume&#x00A0;3 of Dagstuhl Follow-Ups, pages 23&#8211;36.
-                            Schloss Dagstuhl&#8211;Leibniz-Zentrum für Informatik, Dagstuhl,
-                            Germany, 2012. </p>
-                        <p>[7]&#x00A0;&#x00A0;&#x00A0;Emilia Gómez. Tonal Description of Music Audio
-                                Signals. PhD thesis, UPF Barcelona, 2006. </p>
-                        <p>[8]&#x00A0;&#x00A0;&#x00A0;Andrew Hankinson, Perry Roland, and
-                            Ichiro Fujinaga. The music encoding initiative as a document-encoding
-                            framework. In Proceedings of the International Society for Music Information
-                                Retrieval Conference
-                            (ISMIR), pages 293&#8211;298, Miami,
-                            Florida, USA, 2011. </p>
-                        <p>[9]&#x00A0;&#x00A0;&#x00A0;Ning Hu, Roger&#x00A0;B.
-                            Dannenberg, and George Tzanetakis. Polyphonic audio matching and
-                            alignment for music retrieval. In Proceedings
-                                of the IEEE Workshop on Applications of Signal
-                                Processing to Audio and Acoustics (WASPAA), New Paltz, NY, USA,
-                            2003. </p>
-                        <p>[10]&#x00A0;&#x00A0;&#x00A0;Cyril Joder, Slim
-                            Essid, and Gaël Richard. A conditional random field framework for robust
-                            and scalable audio-to-score matching. IEEE
-                                Transactions on Audio, Speech, and Language Processing,
-                            19(8):2385&#8211;2397, 2011. </p>
-                        <p>[11]&#x00A0;&#x00A0;&#x00A0;Johannes Kepper, Solveig
-                            Schreiter, and Joachim Veit. Freischütz analog oder
-                            digital&#8211;editionsformen im spannungsfeld von wissenschaft und
-                            praxis. In Internationales Jahrbuch für Editionswissenschaft, volume&#x00A0;28,
-                            2014. </p>
-                        <p>[12]&#x00A0;&#x00A0;&#x00A0;Elias&#x00A0;K. Kokkinis, Joshua&#x00A0;D. Reiss, and John
-                            Mourjopoulos. A Wiener filter approach to microphone leakage reduction
-                            in close-microphone applications. IEEE
-                                Transactions on Audio, Speech and
-                            Language Processing, 20(3):767&#8211;779,
-                            2012. </p>
-                        <p>[13]&#x00A0;&#x00A0;&#x00A0;>Bernhard Lehner, Gerhard
-                            Widmer, and Reinhard Sonnleitner. On the reduction of false positives in
-                            singing voice detection. In Proceedings
-                            of the IEEE International Conference on Acoustics, Speech, and Signal
-                            Processing (ICASSP), pages 7480&#8211;7484,
-                            Florence, Italy, 2014. </p>
-                        <p>[14]&#x00A0;&#x00A0;&#x00A0;Cynthia C.&#x00A0;S. Liem,
-                            Meinard Müller, Douglas Eck, George Tzanetakis, and Alan Hanjalic. The
-                            need for music information retrieval with user-centered and multimodal
-                            strategies. In Proceedings of the International ACM Workshop on Music Information
-                                Retrieval with User-centered and Multimodal Strategies
-                                (MIRUM), pages 1&#8211;6, 2011. </p>
-                        <p>[15]&#x00A0;&#x00A0;&#x00A0;Antoine Liutkus,
-                            Jean-Louis Durrieu, Laurent Daudet, and Gaël Richard. An overview of
-                            informed audio source separation. In Proceedings
-                                of the International Workshop on Image and Audio Analysis
-                            for Multimedia Interactive Services
-                                (WIAMIS), pages 1&#8211;4, Paris, France, 2013. </p>
-                        <p>[16]&#x00A0;&#x00A0;&#x00A0;Matthias Mauch, Hiromasa
-                            Fujihara, Kazuyoshii Yoshii, and Masataka Goto. Timbre and melody
-                            features for the recognition of vocal activity and instrumental solos in
-                            polyphonic music. In Proceedings of the International Conference on Music Information
-                                Retrieval (ISMIR), pages 233&#8211;238, Miami, Florida, USA,
-                            2011. </p>
-                        <p>[17]&#x00A0;&#x00A0;&#x00A0;Meinard Müller. Information Retrieval for Music and Motion.
-                            Springer Verlag, 2007. </p>
-                        <p>[18]&#x00A0;&#x00A0;&#x00A0;Meinard
-                            Müller, Masataka Goto, and Markus Schedl, editors. Multimodal Music Processing, volume&#x00A0;3 of  
-                            Dagstuhl Follow-Ups. Schloss Dagstuhl -
-                            Leibniz-Zentrum für Informatik, Germany, 2012. </p>
-                        <p>[19]&#x00A0;&#x00A0;&#x00A0;Meinard Müller, Henning Mattes, and
-                            Frank Kurth. An efficient multiscale approach to audio synchronization.
-                            In Proceedings of the International Society for Music Information Retrieval Conference
-                            (ISMIR), pages 192&#8211;197, Victoria,
-                            Canada, 2006. </p>
-                        <p>[20]&#x00A0;&#x00A0;&#x00A0;Meinard Müller, Thomas
-                            Prätzlich, Benjamin Bohl, and Joachim Veit. Freischütz Digital: a
-                            multimodal scenario for informed music processing. In Proceedings of the International Workshop on Image
-                                and Audio Analysis for Multimedia Interactive Services
-                                (WIAMIS), pages 1&#8211;4, Paris, France, 2013. </p>
-                        <p>[21]&#x00A0;&#x00A0;&#x00A0;Yorgos Patsis and Werner
-                            Verhelst. A speech/music/silence/garbage/ classifier for searching and
-                            indexing broadcast news material. In International
-                                Conference on Database and
-                            Expert Systems Application (DEXA), pages
-                            585&#8211;589, Turin, Italy, 2008. </p>
-                        <p>[22]&#x00A0;&#x00A0;&#x00A0;Thomas Prätzlich, Rachel
-                            Bittner, Antoine Liutkus, and Meinard Müller. Kernel additive modeling
-                            for interference reduction in multi-channel music recordings. In Proceedings of the IEEE
-                            International Conference on Acoustics, Speech, and
-                                Signal Processing
-                            (ICASSP), 2015. </p>
-                        <p>[23]&#x00A0;&#x00A0;&#x00A0;Thomas
-                            Prätzlich and Meinard Müller. Freischütz Digital: a case study for
-                            reference-based audio segmentation of operas. In Proceedings of
-                            the International Conference on Music Information
-                                Retrieval (ISMIR), pages 589&#8211;594, Curitiba, Brazil,
-                            2013. </p>
-                        <p>[24]&#x00A0;&#x00A0;&#x00A0;Thomas Prätzlich and
-                            Meinard Müller. Frame-level audio segmentation for abridged musical
-                            works. In Proceedings of the
-                            International Society for Music Information
-                                Retrieval Conference
-                            (ISMIR), pages 307&#8211;312, Taipei,
-                            Taiwan, 2014. </p>
-                        <p>[25]&#x00A0;&#x00A0;&#x00A0;Mathieu Ramona, Gäel Richard,
-                            and Bertrand David. Vocal detection in music with support vector
-                            machines. In Proceedings of
-                            the IEEE International Conference on Acoustics,
-                                Speech, and Signal
-                            Processing (ICASSP), pages 1885&#8211;1888,
-                            Las Vegas, Nevada, USA, 2008. </p>
-                        <p>[26]&#x00A0;&#x00A0;&#x00A0;Daniel Röwenstrunk, Thomas
-                            Prätzlich, Thomas Betzwieser, Meinard Müller, Gerd Szwillus, and Joachim
-                            Veit. Das Gesamtkunstwerk Oper aus Datensicht &#8211; Aspekte des
-                            Umgangs mit einer heterogenen Datenlage im BMBF-Projekt
-                            &#8220;Freischütz Digital&#8221;. Datenbank-Spektrum, 15(1):65&#8211;72, 2015. </p>
-                        <p>[27]&#x00A0;&#x00A0;&#x00A0;S.&#x00A0;Salvador and P.&#x00A0;Chan.
-                            FastDTW: Toward accurate dynamic time warping in linear time and space.
-                            In Proceedings of the KDD Workshop
-                            on Mining Temporal and Sequential Data,
-                            2004. </p>
-                        <p>[28]&#x00A0;&#x00A0;&#x00A0;John Saunders.
-                            Real-time discrimination of broadcast speech/music. In Proceedings of the IEEE International Conference on
-                                Acoustics, Speech and Signal Processing (ICASSP),
-                            volume&#x00A0;2, pages 993&#8211;996. IEEE, 1996. </p>
-                        <p>[29]&#x00A0;&#x00A0;&#x00A0;Solveig Schreiter.Friedrich Kind &amp; Carl Maria von Weber -
-                                Der Freischütz. Kritische
-                                Textbuch-Edition. Allitera Verlag, 2007. </p>
-                        <p>[30]&#x00A0;&#x00A0;&#x00A0;Reinhard Sonnleitner,
-                            Bernhard Niedermayer, Gerhard Widmer, and Jan Schlüter. A simple and
-                            effective spectral feature for speech detection in mixed audio signals.
-                            In Proceedings of the International
-                                Conference
-                            on Digital Audio Effects (DAFx), 2012. </p>
-                        <p>[31]&#x00A0;&#x00A0;&#x00A0;Emmanuel Vincent, Nancy
-                            Bertin, Rémi Gribonval, and Frédéric Bimbot. From blind to guided audio
-                            source separation: How models and side information can improve the
-                            separation of sound. IEEE Signal
-                            Processing Magazine, 31(3):107&#8211;115,
-                            2014. </p>
-                        <p>[32]&#x00A0;&#x00A0;&#x00A0;John Warrack. Carl
-                                Maria von Weber. Cambridge University Press, 1976.</p>
+     <p class="bibitem" ><span class="biblabel">
+  [1]&#x00A0;&#x00A0;&#x00A0;</span><a 
+ id="XBishop06_PatternRecognition_Book"></a>Christopher&#x00A0;M. Bishop.  <span 
+class="cmti-12">Pattern recognition and machine learning</span>.
+     Springer, New York, 2006.
+     </p>
+                                                                          
+
+                                                                          
+     <p class="bibitem" ><span class="biblabel">
+  [2]&#x00A0;&#x00A0;&#x00A0;</span><a 
+ id="XDammFTCKM12_DML_IJDL"></a>David   Damm,   Christian   Fremerey,   Verena   Thomas,   Michael
+     Clausen, Frank Kurth, and Meinard Müller. A digital library framework
+     for  heterogeneous  music  collections:  from  document  acquisition  to
+     cross-modal  interaction.   <span 
+class="cmti-12">International  Journal  on  Digital  Libraries:</span>
+     <span 
+class="cmti-12">Special Issue on Music Digital Libraries</span>, 12(2-3):53&#8211;71, 2012.
+     </p>
+     <p class="bibitem" ><span class="biblabel">
+  [3]&#x00A0;&#x00A0;&#x00A0;</span><a 
+ id="XDittmarLPMW15_SingingVoice_ISMIR"></a>Christian Dittmar, Bernhard Lehner, Thomas Prätzlich, Meinard
+     Müller, and Gerhard Widmer.  Cross-version singing voice detection in
+     classical opera recordings.  In <span 
+class="cmti-12">Proceedings of the International Society</span>
+     <span 
+class="cmti-12">for Music Information Retrieval Conference (ISMIR)</span>, Malaga, Spain,
+     October 2015.
+     </p>
+     <p class="bibitem" ><span class="biblabel">
+  [4]&#x00A0;&#x00A0;&#x00A0;</span><a 
+ id="XDittmarPM15_SingingVoice_DAGA"></a>Christian Dittmar, Thomas Prätzlich, and Meinard Müller. Towards
+     cross-version singing voice detection. In <span 
+class="cmti-12">Proceedings of the Jahrestagung</span>
+     <span 
+class="cmti-12">f</span><span 
+class="cmti-12">ür Akustik (DAGA)</span>, Nuremberg, Germany, March 2015.
+     </p>
+     <p class="bibitem" ><span class="biblabel">
+  [5]&#x00A0;&#x00A0;&#x00A0;</span><a 
+ id="XEwertMG09_HighResAudioSync_ICASSP"></a>Sebastian  Ewert,  Meinard  Müller,  and  Peter  Grosche.     High
+     resolution  audio  synchronization  using  chroma  onset  features.    In
+     <span 
+class="cmti-12">Proceedings of the IEEE International Conference on Acoustics, Speech,</span>
+     <span 
+class="cmti-12">and  Signal  Processing  (ICASSP)</span>,  pages  1869&#8211;1872,  Taipei,  Taiwan,
+     2009.
+     </p>
+     <p class="bibitem" ><span class="biblabel">
+  [6]&#x00A0;&#x00A0;&#x00A0;</span><a 
+ id="XFujiharaG12_LyricsAudio_DagstuhlFU"></a>Hiromasa Fujihara and Masataka Goto.  Lyrics-to-audio alignment
+     and  its  application.      In  Meinard  Müller,  Masataka  Goto,  and
+     Markus  Schedl,  editors,  <span 
+class="cmti-12">Multimodal  Music  Processing</span>,  volume&#x00A0;3  of
+     <span 
+class="cmti-12">Dagstuhl Follow-Ups</span>, pages 23&#8211;36. Schloss Dagstuhl&#8211;Leibniz-Zentrum
+     für Informatik, Dagstuhl, Germany, 2012.
+     </p>
+     <p class="bibitem" ><span class="biblabel">
+  [7]&#x00A0;&#x00A0;&#x00A0;</span><a 
+ id="XGomez06_PhD"></a>Emilia Gómez.   <span 
+class="cmti-12">Tonal Description of Music Audio Signals</span>.   PhD
+     thesis, UPF Barcelona, 2006.
+                                                                          
+
+                                                                          
+     </p>
+     <p class="bibitem" ><span class="biblabel">
+  [8]&#x00A0;&#x00A0;&#x00A0;</span><a 
+ id="XHankinsonRF11_MEI_ISMIR"></a>Andrew Hankinson, Perry Roland, and Ichiro Fujinaga.  The music
+     encoding initiative as a document-encoding framework.  In <span 
+class="cmti-12">Proceedings</span>
+     <span 
+class="cmti-12">of the International Society for Music Information Retrieval Conference</span>
+     <span 
+class="cmti-12">(ISMIR)</span>, pages 293&#8211;298, Miami, Florida, USA, 2011.
+     </p>
+     <p class="bibitem" ><span class="biblabel">
+  [9]&#x00A0;&#x00A0;&#x00A0;</span><a 
+ id="XHuDT03_audiomatching_WASPAA"></a>Ning Hu, Roger&#x00A0;B. Dannenberg, and George Tzanetakis. Polyphonic
+     audio matching and alignment for music retrieval.  In <span 
+class="cmti-12">Proceedings of</span>
+     <span 
+class="cmti-12">the IEEE Workshop on Applications of Signal Processing to Audio and</span>
+     <span 
+class="cmti-12">Acoustics (WASPAA)</span>, New Paltz, NY, USA, 2003.
+     </p>
+     <p class="bibitem" ><span class="biblabel">
+ [10]&#x00A0;&#x00A0;&#x00A0;</span><a 
+ id="XJoderER11_ConditionalRandomFieldSync_TASLP"></a>Cyril Joder, Slim Essid, and Gaël Richard.  A conditional random
+     field  framework  for  robust  and  scalable  audio-to-score  matching.
+     <span 
+class="cmti-12">IEEE  Transactions  on  Audio,  Speech,  and  Language  Processing</span>,
+     19(8):2385&#8211;2397, 2011.
+     </p>
+     <p class="bibitem" ><span class="biblabel">
+ [11]&#x00A0;&#x00A0;&#x00A0;</span><a 
+ id="XKepperSV14_Freischuetz_EDITIO"></a>Johannes Kepper, Solveig Schreiter, and Joachim Veit.  Freischütz
+     analog oder digital&#8211;editionsformen im spannungsfeld von wissenschaft
+     und  praxis.    In  <span 
+class="cmti-12">Internationales  Jahrbuch  f</span><span 
+class="cmti-12">ür  Editionswissenschaft</span>,
+     volume&#x00A0;28, 2014.
+     </p>
+     <p class="bibitem" ><span class="biblabel">
+ [12]&#x00A0;&#x00A0;&#x00A0;</span><a 
+ id="XKokkinisRM12_MultiChannelLeakageSuppression_IEEE-TASLP"></a>Elias&#x00A0;K.  Kokkinis,  Joshua&#x00A0;D.  Reiss,  and  John  Mourjopoulos.
+     A   Wiener   filter   approach   to   microphone   leakage   reduction   in
+     close-microphone applications. <span 
+class="cmti-12">IEEE Transactions on Audio, Speech and</span>
+     <span 
+class="cmti-12">Language Processing</span>, 20(3):767&#8211;779, 2012.
+     </p>
+     <p class="bibitem" ><span class="biblabel">
+ [13]&#x00A0;&#x00A0;&#x00A0;</span><a 
+ id="XLehnerWS14_SingingVoice_ICASSP"></a>Bernhard Lehner, Gerhard Widmer, and Reinhard Sonnleitner. On
+     the reduction of false positives in singing voice detection. In <span 
+class="cmti-12">Proceedings</span>
+     <span 
+class="cmti-12">of the IEEE International Conference on Acoustics, Speech, and Signal</span>
+     <span 
+class="cmti-12">Processing (ICASSP)</span>, pages 7480&#8211;7484, Florence, Italy, 2014.
+                                                                          
+
+                                                                          
+     </p>
+     <p class="bibitem" ><span class="biblabel">
+ [14]&#x00A0;&#x00A0;&#x00A0;</span><a 
+ id="XLiemMET11_NeedMIR_ACM-MM-MIRUM"></a>Cynthia   C.&#x00A0;S.   Liem,   Meinard   Müller,   Douglas   Eck,   George
+     Tzanetakis, and Alan Hanjalic. The need for music information retrieval
+     with user-centered and multimodal strategies.   In <span 
+class="cmti-12">Proceedings of the</span>
+     <span 
+class="cmti-12">International  ACM  Workshop  on  Music  Information  Retrieval  with</span>
+     <span 
+class="cmti-12">User-centered and Multimodal Strategies (MIRUM)</span>, pages 1&#8211;6, 2011.
+     </p>
+     <p class="bibitem" ><span class="biblabel">
+ [15]&#x00A0;&#x00A0;&#x00A0;</span><a 
+ id="XLiutkusDDR13_InformedSourceSep_WIAMIS"></a>Antoine  Liutkus,  Jean-Louis  Durrieu,  Laurent  Daudet,  and  Gaël
+     Richard.    An  overview  of  informed  audio  source  separation.    In
+     <span 
+class="cmti-12">Proceedings of the International Workshop on Image and Audio Analysis</span>
+     <span 
+class="cmti-12">for Multimedia Interactive Services (WIAMIS)</span>, pages 1&#8211;4, Paris, France,
+     2013.
+     </p>
+     <p class="bibitem" ><span class="biblabel">
+ [16]&#x00A0;&#x00A0;&#x00A0;</span><a 
+ id="XMauchFYG11_VocalDetect_ISMIR"></a>Matthias  Mauch,  Hiromasa  Fujihara,  Kazuyoshii  Yoshii,  and
+     Masataka Goto. Timbre and melody features for the recognition of vocal
+     activity and instrumental solos in polyphonic music.  In <span 
+class="cmti-12">Proceedings of</span>
+     <span 
+class="cmti-12">the International Conference on Music Information Retrieval (ISMIR)</span>,
+     pages 233&#8211;238, Miami, Florida, USA, 2011.
+     </p>
+     <p class="bibitem" ><span class="biblabel">
+ [17]&#x00A0;&#x00A0;&#x00A0;</span><a 
+ id="XMueller07_InformationRetrieval_SPRINGER"></a>Meinard  Müller.    <span 
+class="cmti-12">Information  Retrieval  for  Music  and  Motion</span>.
+     Springer Verlag, 2007.
+     </p>
+     <p class="bibitem" ><span class="biblabel">
+ [18]&#x00A0;&#x00A0;&#x00A0;</span><a 
+ id="XMuellerGS12_MultimodalMusicProcessing_DagstuhlFU"></a>Meinard  Müller,  Masataka  Goto,  and  Markus  Schedl,  editors.
+     <span 
+class="cmti-12">Multimodal Music Processing</span>, volume&#x00A0;3 of <span 
+class="cmti-12">Dagstuhl Follow-Ups</span>. Schloss
+     Dagstuhl - Leibniz-Zentrum für Informatik, Germany, 2012.
+     </p>
+     <p class="bibitem" ><span class="biblabel">
+ [19]&#x00A0;&#x00A0;&#x00A0;</span><a 
+ id="XMuellerMK06_MsDTW_ISMIR"></a>Meinard Müller, Henning Mattes, and Frank Kurth.   An efficient
+     multiscale  approach  to  audio  synchronization.     In  <span 
+class="cmti-12">Proceedings  of</span>
+     <span 
+class="cmti-12">the International Society for Music Information Retrieval Conference</span>
+     <span 
+class="cmti-12">(ISMIR)</span>, pages 192&#8211;197, Victoria, Canada, 2006.
+                                                                          
+
+                                                                          
+     </p>
+     <p class="bibitem" ><span class="biblabel">
+ [20]&#x00A0;&#x00A0;&#x00A0;</span><a 
+ id="XMuellerPBV13_FreischuetzDigital_WIAMIS"></a>Meinard Müller, Thomas Prätzlich, Benjamin Bohl, and Joachim
+     Veit.   Freischütz  Digital:  a  multimodal  scenario  for  informed  music
+     processing. In <span 
+class="cmti-12">Proceedings of the International Workshop on Image and</span>
+     <span 
+class="cmti-12">Audio Analysis for Multimedia Interactive Services (WIAMIS)</span>, pages
+     1&#8211;4, Paris, France, 2013.
+     </p>
+     <p class="bibitem" ><span class="biblabel">
+ [21]&#x00A0;&#x00A0;&#x00A0;</span><a 
+ id="XPatsisV08_SpeechMusicGarbage_DEXA"></a>Yorgos            Patsis            and            Werner            Verhelst.
+     A speech/music/silence/garbage/ classifier for searching and indexing
+     broadcast news material. In <span 
+class="cmti-12">International Conference on Database and</span>
+     <span 
+class="cmti-12">Expert Systems Application (DEXA)</span>, pages 585&#8211;589, Turin, Italy, 2008.
+     </p>
+     <p class="bibitem" ><span class="biblabel">
+ [22]&#x00A0;&#x00A0;&#x00A0;</span><a 
+ id="XPraetzlichBLM15_KAMIR_ICASSP"></a>Thomas Prätzlich, Rachel Bittner, Antoine Liutkus, and Meinard
+     Müller.     Kernel  additive  modeling  for  interference  reduction  in
+     multi-channel   music   recordings.      In   <span 
+class="cmti-12">Proceedings  of  the  IEEE</span>
+     <span 
+class="cmti-12">International Conference on Acoustics, Speech, and Signal Processing</span>
+     <span 
+class="cmti-12">(ICASSP)</span>, 2015.
+     </p>
+     <p class="bibitem" ><span class="biblabel">
+ [23]&#x00A0;&#x00A0;&#x00A0;</span><a 
+ id="XPraetzlichM13_ReferenceBasedSegmentation_ISMIR"></a>Thomas Prätzlich and Meinard Müller.  Freischütz Digital: a case
+     study for reference-based audio segmentation of operas. In <span 
+class="cmti-12">Proceedings of</span>
+     <span 
+class="cmti-12">the International Conference on Music Information Retrieval (ISMIR)</span>,
+     pages 589&#8211;594, Curitiba, Brazil, 2013.
+     </p>
+     <p class="bibitem" ><span class="biblabel">
+ [24]&#x00A0;&#x00A0;&#x00A0;</span><a 
+ id="XPraetzlichM14_AudioTrackSeg_ISMIR"></a>Thomas   Prätzlich   and   Meinard   Müller.      Frame-level   audio
+     segmentation  for  abridged  musical  works.     In  <span 
+class="cmti-12">Proceedings  of  the</span>
+     <span 
+class="cmti-12">International  Society  for  Music  Information  Retrieval  Conference</span>
+     <span 
+class="cmti-12">(ISMIR)</span>, pages 307&#8211;312, Taipei, Taiwan, 2014.
+     </p>
+     <p class="bibitem" ><span class="biblabel">
+ [25]&#x00A0;&#x00A0;&#x00A0;</span><a 
+ id="XRamonaRD08_VocalDetect_ICASSP"></a>Mathieu  Ramona,  Gäel  Richard,  and  Bertrand  David.    Vocal
+                                                                          
+
+                                                                          
+     detection in music with support vector machines.   In <span 
+class="cmti-12">Proceedings of</span>
+     <span 
+class="cmti-12">the IEEE International Conference on Acoustics, Speech, and Signal</span>
+     <span 
+class="cmti-12">Processing (ICASSP)</span>, pages 1885&#8211;1888, Las Vegas, Nevada, USA, 2008.
+     </p>
+     <p class="bibitem" ><span class="biblabel">
+ [26]&#x00A0;&#x00A0;&#x00A0;</span><a 
+ id="XRoewenstrunkPBMSV15_WeberOper_DBSK"></a>Daniel             Röwenstrunk,             Thomas             Prätzlich,
+     Thomas Betzwieser, Meinard Müller, Gerd Szwillus, and Joachim Veit.
+     Das Gesamtkunstwerk Oper aus Datensicht &#8211; Aspekte des Umgangs mit
+     einer heterogenen Datenlage im BMBF-Projekt &#8220;Freischütz Digital&#8221;.
+     <span 
+class="cmti-12">Datenbank-Spektrum</span>, 15(1):65&#8211;72, 2015.
+     </p>
+     <p class="bibitem" ><span class="biblabel">
+ [27]&#x00A0;&#x00A0;&#x00A0;</span><a 
+ id="XSalvadorC04_fastDTW"></a>S.&#x00A0;Salvador and P.&#x00A0;Chan. FastDTW: Toward accurate dynamic time
+     warping in linear time and space. In <span 
+class="cmti-12">Proceedings of the KDD Workshop</span>
+     <span 
+class="cmti-12">on Mining Temporal and Sequential Data</span>, 2004.
+     </p>
+     <p class="bibitem" ><span class="biblabel">
+ [28]&#x00A0;&#x00A0;&#x00A0;</span><a 
+ id="XSaunders96_SpeechMusicDiscrimination_ICASSP"></a>John Saunders. Real-time discrimination of broadcast speech/music.
+     In  <span 
+class="cmti-12">Proceedings  of  the  IEEE  International  Conference  on  Acoustics,</span>
+     <span 
+class="cmti-12">Speech  and  Signal  Processing  (ICASSP)</span>,  volume&#x00A0;2,  pages  993&#8211;996.
+     IEEE, 1996.
+     </p>
+     <p class="bibitem" ><span class="biblabel">
+ [29]&#x00A0;&#x00A0;&#x00A0;</span><a 
+ id="XSchreiter07_FreischuetzLibretto_book"></a>Solveig Schreiter.  <span 
+class="cmti-12">Friedrich Kind &amp; Carl Maria von Weber - Der</span>
+     <span 
+class="cmti-12">Freisch</span><span 
+class="cmti-12">ütz. Kritische Textbuch-Edition</span>. Allitera Verlag, 2007.
+     </p>
+     <p class="bibitem" ><span class="biblabel">
+ [30]&#x00A0;&#x00A0;&#x00A0;</span><a 
+ id="XSonnleitnerNW12_SpeechDetection_DAFX"></a>Reinhard Sonnleitner, Bernhard Niedermayer, Gerhard Widmer, and
+     Jan Schlüter. A simple and effective spectral feature for speech detection
+     in mixed audio signals.  In <span 
+class="cmti-12">Proceedings of the International Conference</span>
+     <span 
+class="cmti-12">on Digital Audio Effects (DAFx)</span>, 2012.
+     </p>
+     <p class="bibitem" ><span class="biblabel">
+ [31]&#x00A0;&#x00A0;&#x00A0;</span><a 
+ id="XVincentBGB14_SourceSep_IEEE-SPM"></a>Emmanuel Vincent, Nancy Bertin, Rémi Gribonval, and Frédéric
+     Bimbot.  From blind to guided audio source separation: How models
+                                                                          
+
+                                                                          
+     and side information can improve the separation of sound. <span 
+class="cmti-12">IEEE Signal</span>
+     <span 
+class="cmti-12">Processing Magazine</span>, 31(3):107&#8211;115, 2014.
+     </p>
+     <p class="bibitem" ><span class="biblabel">
+ [32]&#x00A0;&#x00A0;&#x00A0;</span><a 
+ id="XWarrack76_Weber_book"></a>John Warrack. <span 
+class="cmti-12">Carl Maria von Weber</span>. Cambridge University Press,
+     1976.
+</p>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
the html anchors for the links of the references were missing in the audio documentation.
